### PR TITLE
Rework match grouping to use a graph-based strategy

### DIFF
--- a/dphon/cli.py
+++ b/dphon/cli.py
@@ -81,7 +81,7 @@ Display options:
 
 Examples:
     dphon texts/*.txt > matches.txt
-    dphon file1.txt file2.txt --ngram-order 8 --threshold 0.8
+    dphon file1.txt file2.txt --ngram-order 8 --threshold 0.8 --group
     dphon docs.jsonl --input-format jsonl --output-format jsonl > matches.jsonl
 
 Help:
@@ -151,6 +151,7 @@ def run() -> None:
     graph = process(nlp, args)
 
     # check if we're outputting to a file and find out the format
+    output_format = None
     if args["--output-file"]:
         output_path = Path(args["--output-file"])
         output_format = output_path.suffix.lstrip(".").lower()
@@ -160,6 +161,7 @@ def run() -> None:
     # if requested output match groups, otherwise output matches
     results: List[MatchGroup] | List[Match] = []
     if args["--group"]:
+        graph.group()
         results = graph.groups
     else:
         results = list(graph.matches)
@@ -199,8 +201,6 @@ def setup(args: Dict) -> Language:
     # add Doc metadata
     if not Doc.has_extension("id"):
         Doc.set_extension("id", default="")
-    if not Doc.has_extension("groups"):
-        Doc.set_extension("groups", default=[])
 
     # setup spaCy model
     nlp = spacy.blank("zh", meta={"tokenizer": {"config": {"use_jieba": False}}})
@@ -297,9 +297,6 @@ def process(nlp: Language, args: Dict) -> MatchGraph:
         graph.filter(
             lambda m: m.phonetic_similarity <= float(args["--max-phonetic-similarity"])
         )
-
-    # group all matches
-    graph.group()
 
     # return completed reuse graph
     return graph

--- a/dphon/console.py
+++ b/dphon/console.py
@@ -93,7 +93,6 @@ class MatchHighlighter(RegexHighlighter):
             return span.text
 
         # o(N) implementation: step through each sequence adding markup
-        # TODO convert to a DFA so there's less markup repetition?
         marked_span: List[str] = []
         span_ptr = 0
         other_ptr = 0

--- a/dphon/match.py
+++ b/dphon/match.py
@@ -23,6 +23,21 @@ class Match(NamedTuple):
     au: List[str] = []
     av: List[str] = []
 
+    def __key(self) -> tuple:
+        return (
+            *sorted((self.u, self.v)),
+            *sorted((self.utxt.text, self.vtxt.text)),
+        )
+
+    def __hash__(self) -> int:
+        return hash(self.__key())
+
+    def __eq__(self, value: object) -> bool:
+        """Matches are equal if they have the same text in the same documents."""
+        if isinstance(value, Match):
+            return self.__key() == value.__key()
+        return NotImplemented
+
     def __len__(self) -> int:
         """Length of the longer sequence in the match."""
         return max(len(self.utxt), len(self.vtxt))
@@ -32,7 +47,7 @@ class Match(NamedTuple):
     ) -> RenderResult:
         """Format the match for display in console."""
         table = Table(show_header=False, box=None)
-        table.add_column("doc")
+        table.add_column("doc", no_wrap=True)
         table.add_column("bounds")
         table.add_column("text")
         table.add_column("transcription")

--- a/tests/unit/test_match.py
+++ b/tests/unit/test_match.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 import spacy
+
 from dphon.match import Match
 
 
@@ -44,3 +45,7 @@ class TestMatch(TestCase):
         # pre-copied spans should also be equal
         m3 = Match("doc1", "doc2", self.doc1[4:6], self.doc2[2:4])
         self.assertEqual(m1, m3)
+
+        # u -> v should be equal to v -> u
+        m4 = Match("doc2", "doc1", vtxt, utxt)
+        self.assertEqual(m1, m4)


### PR DESCRIPTION
This refactors match grouping to use a graph algorithm to group
matches (connected components) which helps ensure that groups
are unique.

Also updates the console display for groups to match current
display for non-grouped matches.
