### PR TITLE
dphon improvements

### DIFF
--- a/src/dphon/align.py
+++ b/src/dphon/align.py
@@ -88,13 +88,13 @@ class SmithWatermanAligner(Aligner):
 
         # trim back the sequence boundaries further to remove any non-alphanum.
         # tokens from the start and end of both alignment and orig. sequence
-        while (not au[-1].isalnum() and au[-1] != self.gap_char) or (not av[-1].isalnum() and av[-1] != self.gap_char):
+        while au and av and ((not au[-1].isalnum() and au[-1] != self.gap_char) or (not av[-1].isalnum() and av[-1] != self.gap_char)):
             utxt, vtxt, au, av = utxt[:-1], vtxt[:-1], au[:-1], av[:-1]
-        while (not au[0].isalnum() and au[0] != self.gap_char) or (not av[0].isalnum() and av[0] != self.gap_char):
+        while au and av and ((not au[0].isalnum() and au[0] != self.gap_char) or (not av[0].isalnum() and av[0] != self.gap_char)):
             utxt, vtxt, au, av = utxt[1:], vtxt[1:], au[1:], av[1:]
 
         # normalize score to length; 1.0 is perfect
-        norm_score = float(score) / max(len(au), len(av))
+        norm_score = float(score) / max(len(au), len(av), 1)
 
         # create a new match with alignment info and adjusted boundaries
         return Match(match.u, match.v, utxt, vtxt, norm_score, au, av)

--- a/src/dphon/align.py
+++ b/src/dphon/align.py
@@ -65,8 +65,8 @@ class SmithWatermanAligner(Aligner):
         # ---->                <----
         u, v = match.utxt.doc, match.vtxt.doc
         us, vs = match.utxt.start + len(lu), match.vtxt.start + len(lv)
-        utxt = u[us : us + len(cu)]
-        vtxt = v[vs : vs + len(cv)]
+        utxt = u[us : us + sum(1 for c in cu if c != "-")]
+        vtxt = v[vs : vs + sum(1 for c in cv if c != "-")]
 
         # use the gaps in the alignment to construct a new sequence of token
         # texts, inserting gap_char wherever the aligner created a gap
@@ -88,9 +88,9 @@ class SmithWatermanAligner(Aligner):
 
         # trim back the sequence boundaries further to remove any non-alphanum.
         # tokens from the start and end of both alignment and orig. sequence
-        while not au[-1].isalnum() or not av[-1].isalnum():
+        while (not au[-1].isalnum() and au[-1] != self.gap_char) or (not av[-1].isalnum() and av[-1] != self.gap_char):
             utxt, vtxt, au, av = utxt[:-1], vtxt[:-1], au[:-1], av[:-1]
-        while not au[0].isalnum() or not av[0].isalnum():
+        while (not au[0].isalnum() and au[0] != self.gap_char) or (not av[0].isalnum() and av[0] != self.gap_char):
             utxt, vtxt, au, av = utxt[1:], vtxt[1:], au[1:], av[1:]
 
         # normalize score to length; 1.0 is perfect

--- a/src/dphon/cli.py
+++ b/src/dphon/cli.py
@@ -43,6 +43,26 @@ Matching Options:
     -c <NUM>, --context <NUM>       [default: 4]
         Add NUM tokens of context to each side of matches. Context displays with
         a dimmed appearance if color is supported in the terminal.
+    
+    --fuzzy-initials            [default: False]
+        Seed matches across initials that share a place of articulation but
+        differ in voicing/aspiration (e.g. *b- *p- *pʰ-). Off by default.
+
+    --initial-class-threshold <NUM>  [default: 7]
+        Minimum substitution score for two obstruents to share a place-class.
+        Lower = coarser. Only affects --fuzzy-initials.
+
+    --fold-homorganic-nasals    [default: False]
+        Additionally fold each nasal (m n ŋ ŋʷ) into its homorganic obstruent
+        class. Liquids, glides, and fricatives are never folded.
+
+    --fuzzy-rimes               [default: False]
+        Seed matches across rimes in the same traditional rhyme category (韻部),
+        e.g. 真 *-in/*-iŋ. Off by default (rime must match exactly).
+
+    --rhyme-categories <PATH>
+        Yunelizer-syntax rhyme file used by --fuzzy-rimes. Parsed, not executed.
+        Defaults to the bundled data/rhyme-categories.txt.
 
 Filtering Options:
     --within-doc               [default: False]
@@ -126,6 +146,12 @@ from .console import MatchHighlighter, console, err_console
 from .corpus import CorpusLoader, JsonLinesCorpusLoader, PlaintextCorpusLoader
 from .extend import LevenshteinPhoneticExtender
 from .g2p import get_sound_table_json
+from .fuzzyphon import (
+    build_initial_classes,
+    load_rhyme_classes,
+    warn_unattested_initials,
+    warn_unattested_rhymes,
+)
 from .match import Match
 from .reuse import MatchGraph, MatchGroup
 
@@ -233,6 +259,33 @@ def setup(args: Dict) -> Language:
     v2_path = pkg_resources.files(__package__).joinpath("data/sound_table_v2.json")
     sound_table = get_sound_table_json(v2_path)
 
+    # build fuzzy seed-classes (empty unless explicitly enabled)
+    initial_classes: Dict[str, str] = {}
+    if args["--fuzzy-initials"]:
+        cons_path = pkg_resources.files(__package__).joinpath("data/oc-consonants.txt")
+        initial_classes = build_initial_classes(
+            cons_path,
+            threshold=int(args["--initial-class-threshold"]),
+            fold_homorganic_nasals=bool(args["--fold-homorganic-nasals"]),
+        )
+        warn_unattested_initials(sound_table, initial_classes, initial_idx=3)
+
+    rhyme_classes: Dict = {}
+    nucleus_norm: Dict[str, str] = {}
+    if args["--fuzzy-rimes"]:
+        if args["--rhyme-categories"]:
+            rc_path = Path(args["--rhyme-categories"])
+            if not rc_path.exists():
+                raise FileNotFoundError(f"rhyme categories file not found: {rc_path}")
+        else:
+            rc_path = pkg_resources.files(__package__).joinpath("data/rhyme-categories.txt")
+        rhyme_classes = load_rhyme_classes(rc_path)
+        nucleus_norm = {"A": "a"}      # seed-key normalization only
+        warn_unattested_rhymes(
+            sound_table, rhyme_classes,
+            nucleus_idx=6, coda_idx=7, nucleus_norm=nucleus_norm,
+        )
+
     # add Doc metadata
     if not Doc.has_extension("id"):
         Doc.set_extension("id", default="")
@@ -240,6 +293,10 @@ def setup(args: Dict) -> Language:
     # setup spaCy model
     nlp = spacy.blank("zh", meta={"tokenizer": {"config": {"use_jieba": False}}})
     nlp.add_pipe("g2p", config={"sound_table": sound_table})
+    g2p = nlp.get_pipe("g2p")
+    g2p.initial_classes = initial_classes
+    g2p.rhyme_classes = rhyme_classes
+    g2p.nucleus_norm = nucleus_norm
     nlp.add_pipe("ngrams", config={"n": int(args["--ngram-order"])})
     nlp.add_pipe("ngram_phonemes_index", name="index")
     logging.info("loaded default spaCy model")

--- a/src/dphon/cli.py
+++ b/src/dphon/cli.py
@@ -205,15 +205,16 @@ def run() -> None:
 
     # output depending on provided option
     if output_format == "jsonl":
-        with jsonlines.Writer(output_path) as writer:
+         with open(output_path, "w") as f, jsonlines.Writer(f) as writer:
             for result in results:
                 writer.write(result.as_dict())
     elif output_format == "csv":
         fieldnames = results[0].as_dict().keys()
-        writer = csv.DictWriter(output_path, fieldnames=fieldnames)
-        writer.writeheader()
-        for result in results:
-            writer.writerow(result.as_dict())
+        with open(output_path, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            for result in results:
+                writer.writerow(result.as_dict())
     elif output_format == "html":
         console.record = True
         for result in results:

--- a/src/dphon/cli.py
+++ b/src/dphon/cli.py
@@ -45,6 +45,9 @@ Matching Options:
         a dimmed appearance if color is supported in the terminal.
 
 Filtering Options:
+    --within-doc               [default: False]
+        Allow matches within the same document. Overlapping spans are
+        automatically excluded.
     -a, --all
         Allow matches without graphic variation. By default, only matches
         containing at least one token with shared phonemes but differing
@@ -75,6 +78,9 @@ Filtering Options:
         to allow matches that are phonetically identical (1).
 
 Display options:
+    --transcribe-context        [default: False]
+        Include phonemic transcription for context tokens as well as matched
+        tokens.
     -g, --group                [default: False]
         Group matches by shared text. By default, matches are displayed as
         individual pairs of similar sequences.
@@ -144,7 +150,7 @@ def run() -> None:
 
     # setup match highlighting
     console.highlighter = MatchHighlighter(
-        g2p=nlp.get_pipe("g2p"), context=int(args["--context"]), gap_char="　"
+        g2p=nlp.get_pipe("g2p"), context=int(args["--context"]), gap_char="　", transcribe_context=args["--transcribe-context"]
     )
 
     # process all texts
@@ -253,7 +259,7 @@ def process(nlp: Language, args: Dict) -> MatchGraph:
             )
             progress.update(task, seed=locations[0].text)
             for utxt, vtxt in combinations(locations, 2):
-                if utxt.doc._.id != vtxt.doc._.id:  # skip same-doc matches
+                if utxt.doc._.id != vtxt.doc._.id or (args["--within-doc"] and (utxt.end <= vtxt.start or vtxt.end <= utxt.start)):
                     graph.add_match(
                         Match(utxt.doc._.id, vtxt.doc._.id, utxt, vtxt, 1.0)
                     )
@@ -272,6 +278,14 @@ def process(nlp: Language, args: Dict) -> MatchGraph:
             threshold=float(args["--threshold"]), len_limit=int(args["--len-limit"])
         )
     )
+    
+    # remove same-doc matches that overlap after extension
+    if args["--within-doc"]:
+        def no_overlap(match: Match) -> bool:
+            if match.u != match.v:
+                return True
+            return match.utxt.end <= match.vtxt.start or match.vtxt.end <= match.utxt.start
+        graph.filter(no_overlap)
 
     # align all matches
     graph.align(SmithWatermanPhoneticAligner(gap_char="　"))

--- a/src/dphon/cli.py
+++ b/src/dphon/cli.py
@@ -152,7 +152,7 @@ from .fuzzyphon import (
     warn_unattested_initials,
     warn_unattested_rhymes,
 )
-from .match import Match
+from .match import GAP, Match
 from .reuse import MatchGraph, MatchGroup
 
 # Available log levels: default is WARN, -v is INFO, -vv is DEBUG
@@ -182,7 +182,7 @@ def run() -> None:
 
     # setup match highlighting
     console.highlighter = MatchHighlighter(
-        g2p=nlp.get_pipe("g2p"), context=int(args["--context"]), gap_char="　", transcribe_context=args["--transcribe-context"]
+        g2p=nlp.get_pipe("g2p"), context=int(args["--context"]), gap_char=GAP, transcribe_context=args["--transcribe-context"]
     )
 
     # process all texts
@@ -380,7 +380,7 @@ def process(nlp: Language, args: Dict) -> MatchGraph:
         graph.filter(no_overlap)
 
     # align all matches
-    graph.align(SmithWatermanPhoneticAligner(gap_char="　"))
+    graph.align(SmithWatermanPhoneticAligner(gap_char=GAP))
 
     # filter if requested
     if args["--min-length"]:

--- a/src/dphon/cli.py
+++ b/src/dphon/cli.py
@@ -48,6 +48,7 @@ Filtering Options:
     --within-doc               [default: False]
         Allow matches within the same document. Overlapping spans are
         automatically excluded.
+
     -a, --all
         Allow matches without graphic variation. By default, only matches
         containing at least one token with shared phonemes but differing
@@ -76,6 +77,11 @@ Filtering Options:
     --max-phonetic-similarity <NUM>  [default: 1]
         Limit to matches with a phonetic similarity ratio <= NUM. The default is
         to allow matches that are phonetically identical (1).
+
+    --focus <ID>
+        One-to-many mode: only find matches where at least one span is from
+        the document whose ID starts with ID. Results are ordered by position
+        in the focus text.
 
 Display options:
     --transcribe-context        [default: False]
@@ -172,8 +178,30 @@ def run() -> None:
     else:
         results = list(graph.matches)
 
-    # sort results by highest weighted score
-    results = sorted(results, key=lambda result: result.weighted_score, reverse=True)
+    # sort results
+    if args["--focus"]:
+        # order by position in source text
+        source = args["--focus"]
+        def source_position(match):
+            if match.u.startswith(source):
+                return (match.u, match.utxt.start)
+            else:
+                return (match.v, match.vtxt.start)
+        results= sorted(results, key=source_position)
+    else:
+        # sort results by highest weighted score
+        results = sorted(results, key=lambda result: result.weighted_score, reverse=True)
+
+    # normalize so focus is always the first (u) position
+    if args["--focus"]:
+        normalized = []
+        for match in results:
+            if match.v.startswith(args["--focus"]) and not match.u.startswith(args["--focus"]):
+                normalized.append(Match(match.v, match.u, match.vtxt, match.utxt,
+                                       match.weight, match.av, match.au))
+            else:
+                normalized.append(match)
+        results = normalized
 
     # output depending on provided option
     if output_format == "jsonl":
@@ -259,6 +287,12 @@ def process(nlp: Language, args: Dict) -> MatchGraph:
             )
             progress.update(task, seed=locations[0].text)
             for utxt, vtxt in combinations(locations, 2):
+                # source filter: skip pairs where neither doc is the source
+                if args["--focus"]:
+                    u_is_source = utxt.doc._.id.startswith(args["--focus"])
+                    v_is_source = vtxt.doc._.id.startswith(args["--focus"])
+                    if not u_is_source and not v_is_source:
+                        continue
                 if utxt.doc._.id != vtxt.doc._.id or (args["--within-doc"] and (utxt.end <= vtxt.start or vtxt.end <= utxt.start)):
                     graph.add_match(
                         Match(utxt.doc._.id, vtxt.doc._.id, utxt, vtxt, 1.0)

--- a/src/dphon/console.py
+++ b/src/dphon/console.py
@@ -28,7 +28,7 @@ class MatchHighlighter(RegexHighlighter):
     g2p: GraphemesToPhonemes
 
     def __init__(
-        self, g2p: GraphemesToPhonemes, context: int = 0, gap_char: str = "-"
+        self, g2p: GraphemesToPhonemes, context: int = 0, gap_char: str = "-", transcribe_context: bool = False
     ) -> None:
         """Create a new highlighter with optional context for each match."""
         # can't have negative context
@@ -38,6 +38,7 @@ class MatchHighlighter(RegexHighlighter):
         # store parameters
         self.context = context
         self.gap_char = gap_char
+        self.transcribe_context = transcribe_context
         self.g2p = g2p
         super().__init__()
 
@@ -53,8 +54,33 @@ class MatchHighlighter(RegexHighlighter):
         )
 
     def transcribe_match(self, match: Match) -> Tuple[str, str]:
-        """Render a phonemic transcription for a Match."""
-        return (self.transcribe_span(match.utxt), self.transcribe_span(match.vtxt))
+        """Render a phonemic transcription for a Match"""
+        if self.transcribe_context:
+            return (
+                self.transcribe_span_with_context(match.utxt),
+                self.transcribe_span_with_context(match.vtxt),
+            )
+        else:
+            return (self.transcribe_span(match.utxt), self.transcribe_span(match.vtxt))
+        
+    def transcribe_span_with_context(self, span: Span) -> str:
+        """Render a phonemic transcription for a Span, including context."""
+        parts = []
+        if self.context > 0:
+            ctx_left = span.doc[max(0, span.start - self.context) : span.start]
+            if len(ctx_left) > 0:
+                left_syls = " ".join(s for s in ctx_left._.syllables if s)
+                if left_syls:
+                    parts.append(f"[context]{left_syls}[/context]")
+        match_syls = " ".join(span._.syllables)
+        parts.append(match_syls)
+        if self.context > 0:
+            ctx_right = span.doc[span.end : span.end + self.context]
+            if len(ctx_right) > 0:
+                right_syls = " ".join(s for s in ctx_right._.syllables if s)
+                if right_syls:
+                    parts.append(f"[context]{right_syls}[/context]")
+        return "*" + " ".join(parts)
 
     def format_span(
         self,

--- a/src/dphon/console.py
+++ b/src/dphon/console.py
@@ -54,14 +54,33 @@ class MatchHighlighter(RegexHighlighter):
         )
 
     def transcribe_match(self, match: Match) -> Tuple[str, str]:
-        """Render a phonemic transcription for a Match"""
-        if self.transcribe_context:
-            return (
-                self.transcribe_span_with_context(match.utxt),
-                self.transcribe_span_with_context(match.vtxt),
-            )
-        else:
-            return (self.transcribe_span(match.utxt), self.transcribe_span(match.vtxt))
+        """Render a phonemic transcription for a Match, with optional context."""
+        u_transcription = self._mark_transcription(
+            match.utxt, match.au, match.vtxt, match.av
+        )
+        v_transcription = self._mark_transcription(
+            match.vtxt, match.av, match.utxt, match.au
+        )
+        if self.transcribe_context and self.context > 0:
+            u_transcription = self._add_transcription_context(match.utxt, u_transcription)
+            v_transcription = self._add_transcription_context(match.vtxt, v_transcription)
+        return (u_transcription, v_transcription)
+       
+    def _add_transcription_context(self, span: Span, transcription: str) -> str:
+        """Wrap a transcription with context phonemes."""
+        parts = []
+        ctx_left = span.doc[max(0, span.start - self.context) : span.start]
+        if len(ctx_left) > 0:
+            left_syls = " ".join(s for s in ctx_left._.syllables if s)
+            if left_syls:
+                parts.append(f"[context]{left_syls}[/context]")
+        parts.append(transcription.lstrip("*"))
+        ctx_right = span.doc[span.end : span.end + self.context]
+        if len(ctx_right) > 0:
+            right_syls = " ".join(s for s in ctx_right._.syllables if s)
+            if right_syls:
+                parts.append(f"[context]{right_syls}[/context]")
+        return "*" + " ".join(parts)
         
     def transcribe_span_with_context(self, span: Span) -> str:
         """Render a phonemic transcription for a Span, including context."""
@@ -81,6 +100,64 @@ class MatchHighlighter(RegexHighlighter):
                 if right_syls:
                     parts.append(f"[context]{right_syls}[/context]")
         return "*" + " ".join(parts)
+    
+    def _mark_transcription(
+        self, span: Span, alignment: str, other: Span, other_alignment: str
+    ) -> str:
+        """Mark up a phonemic transcription with the same color coding as _mark_span."""
+        if not alignment or not other or not other_alignment:
+            return "*" + " ".join(span._.syllables)
+
+        marked: List[str] = []
+        span_ptr = 0
+        other_ptr = 0
+        for i in range(len(alignment)):
+            # gap in u: insertion in v
+            if alignment[i] == self.gap_char and other_alignment[i].isalnum():
+                other_ptr += 1
+                continue
+
+            # gap in v: insertion in u
+            if other_alignment[i] == self.gap_char and alignment[i].isalnum():
+                if span_ptr < len(span):
+                    syl = self.g2p._get_token_syllable(span[span_ptr])
+                    if syl:
+                        marked.append(f"[insertion]{syl}[/insertion]")
+                span_ptr += 1
+                continue
+
+            # bounds check
+            if span_ptr >= len(span) or other_ptr >= len(other):
+                span_ptr += 1
+                other_ptr += 1
+                continue
+            
+            syl = self.g2p._get_token_syllable(span[span_ptr])
+
+            # variants
+            if self.g2p.are_graphic_variants(span[span_ptr], other[other_ptr]):
+                if syl:
+                    marked.append(f"[variant]{syl}[/variant]")
+                span_ptr += 1
+                other_ptr += 1
+                continue
+
+            # mismatch
+            if alignment[i] != other_alignment[i]:
+                if alignment[i].isalnum() and other_alignment[i].isalnum():
+                    if syl:
+                        marked.append(f"[mismatch]{syl}[/mismatch]")
+                    span_ptr += 1
+                    other_ptr += 1
+                    continue
+
+            # equality
+            if syl:
+                marked.append(syl)
+            span_ptr += 1
+            other_ptr += 1
+
+        return "*" + " ".join(marked)
 
     def format_span(
         self,

--- a/src/dphon/console.py
+++ b/src/dphon/console.py
@@ -12,7 +12,7 @@ from .match import Match
 
 # Default color scheme for highlighting matches
 DEFAULT_THEME = Theme(
-    {"context": "dim", "variant": "blue", "insertion": "green", "mismatch": "red"}
+    {"context": "dim", "variant": "blue", "fuzzy": "dark_cyan", "insertion": "green", "mismatch": "red"}
 )
 
 # Consoles for rendering output
@@ -142,11 +142,24 @@ class MatchHighlighter(RegexHighlighter):
                 other_ptr += 1
                 continue
 
-            # mismatch
+            # mismatch — but flag positions that match only under fuzzy seeding
             if alignment[i] != other_alignment[i]:
                 if alignment[i].isalnum() and other_alignment[i].isalnum():
+                    fuzzy_active = bool(
+                        self.g2p.initial_classes
+                        or self.g2p.rhyme_classes
+                        or self.g2p.nucleus_norm
+                    )
+                    is_fuzzy = (
+                        fuzzy_active
+                        and not span[span_ptr]._.is_oov
+                        and not other[other_ptr]._.is_oov
+                        and self.g2p.get_token_seed_key(span[span_ptr])
+                            == self.g2p.get_token_seed_key(other[other_ptr])
+                    )
+                    style = "fuzzy" if is_fuzzy else "mismatch"
                     if syl:
-                        marked.append(f"[mismatch]{syl}[/mismatch]")
+                        marked.append(f"[{style}]{syl}[/{style}]")
                     span_ptr += 1
                     other_ptr += 1
                     continue
@@ -225,10 +238,23 @@ class MatchHighlighter(RegexHighlighter):
                 other_ptr += 1
                 continue
 
-            # mismatch (both u and v) - only highlight if alphanumeric
+            # mismatch (both u and v) — flag fuzzy-equivalent positions distinctly
             if alignment[i] != other_alignment[i]:
                 if alignment[i].isalnum() and other_alignment[i].isalnum():
-                    marked_span.append(f"[mismatch]{alignment[i]}[/mismatch]")
+                    fuzzy_active = bool(
+                        self.g2p.initial_classes
+                        or self.g2p.rhyme_classes
+                        or self.g2p.nucleus_norm
+                    )
+                    is_fuzzy = (
+                        fuzzy_active
+                        and not span[span_ptr]._.is_oov
+                        and not other[other_ptr]._.is_oov
+                        and self.g2p.get_token_seed_key(span[span_ptr])
+                            == self.g2p.get_token_seed_key(other[other_ptr])
+                    )
+                    style = "fuzzy" if is_fuzzy else "mismatch"
+                    marked_span.append(f"[{style}]{alignment[i]}[/{style}]")
                     span_ptr += 1
                     other_ptr += 1
                     continue

--- a/src/dphon/console.py
+++ b/src/dphon/console.py
@@ -96,7 +96,7 @@ class MatchHighlighter(RegexHighlighter):
         marked_span: List[str] = []
         span_ptr = 0
         other_ptr = 0
-        for i in range(len(span)):
+        for i in range(len(alignment)):
             # gap in u: insertion in v (if not punctuation)
             if alignment[i] == self.gap_char and other_alignment[i].isalnum():
                 other_ptr += 1
@@ -108,6 +108,13 @@ class MatchHighlighter(RegexHighlighter):
                 span_ptr += 1
                 continue
 
+            # if either pointer is out of bounds, just append the character
+            if span_ptr >= len(span) or other_ptr >= len(other):
+                marked_span.append(alignment[i])
+                span_ptr += 1
+                other_ptr += 1
+                continue
+            
             # variants (both u and v)
             if self.g2p.are_graphic_variants(span[span_ptr], other[other_ptr]):
                 marked_span.append(f"[variant]{alignment[i]}[/variant]")

--- a/src/dphon/console.py
+++ b/src/dphon/console.py
@@ -112,19 +112,22 @@ class MatchHighlighter(RegexHighlighter):
         span_ptr = 0
         other_ptr = 0
         for i in range(len(alignment)):
-            # gap in u: insertion in v
-            if alignment[i] == self.gap_char and other_alignment[i].isalnum():
-                other_ptr += 1
+            # gap on this side: nothing to show here; advance the other pointer
+            # only when the other side actually has a token in this column
+            if alignment[i] == self.gap_char:
+                if other_alignment[i] != self.gap_char:
+                    other_ptr += 1
                 continue
 
-            # gap in v: insertion in u
-            if other_alignment[i] == self.gap_char and alignment[i].isalnum():
+            # gap on the other side: this token is an insertion
+            if other_alignment[i] == self.gap_char:
                 if span_ptr < len(span):
                     syl = self.g2p._get_token_syllable(span[span_ptr])
                     if syl:
                         marked.append(f"[insertion]{syl}[/insertion]")
                 span_ptr += 1
                 continue
+
 
             # bounds check
             if span_ptr >= len(span) or other_ptr >= len(other):
@@ -213,14 +216,19 @@ class MatchHighlighter(RegexHighlighter):
         span_ptr = 0
         other_ptr = 0
         for i in range(len(alignment)):
-            # gap in u: insertion in v (if not punctuation)
-            if alignment[i] == self.gap_char and other_alignment[i].isalnum():
-                other_ptr += 1
+            # gap on this side: nothing to show here; advance the other pointer
+            # only when the other side actually has a token in this column
+            if alignment[i] == self.gap_char:
+                if other_alignment[i] != self.gap_char:
+                    other_ptr += 1
                 continue
 
-            # gap in v: insertion in u (if not punctuation)
-            if other_alignment[i] == self.gap_char and alignment[i].isalnum():
-                marked_span.append(f"[insertion]{alignment[i]}[/insertion]")
+            # gap on the other side: this token is an insertion
+            if other_alignment[i] == self.gap_char:
+                if alignment[i].isalnum():
+                    marked_span.append(f"[insertion]{alignment[i]}[/insertion]")
+                else:
+                    marked_span.append(alignment[i])
                 span_ptr += 1
                 continue
 

--- a/src/dphon/data/rhyme-categories.txt
+++ b/src/dphon/data/rhyme-categories.txt
@@ -1,0 +1,220 @@
+#note that noted mergers into rhyme groups 脂, 質, and 真 are assumed to have occurred during earliest corpus of poetry
+#comp. Gassmann & Behr, Grammatik, 2013: 445]
+
+#之
+rime_ə = "ə0.."
+#幽A
+rime_u = "u0.."
+#支
+rime_e = "e0.."
+#魚
+rime_a = "a0.."
+#侯
+rime_o = "o0.."
+#*-i n/a (=*-ij)
+#list of open coda rimes
+rimes_opencoda = [rime_ə, rime_u, rime_e, rime_a, rime_o]
+
+
+#幽B
+rime_iw = "iw.."
+#宵A
+rime_ew = "ew.."
+#宵B
+rime_aw = "aw.."
+#*əw, *uw, *ow n/a
+#list of *-w coda rimes
+rimes_wcoda = [rime_iw, rime_ew, rime_aw]
+
+#*-ik coda (under 質)
+rime_ik = "ik.."
+#識
+rime_ək = "ək.."
+#覺A
+rime_uk = "uk.."
+#錫
+rime_ek = "ek.."
+#鐸
+rime_ak = "ak.."
+#屋
+rime_ok = "ok.."
+#list of *-k coda rimes
+rimes_kcoda = [rime_ik, rime_ək, rime_uk, rime_ek, rime_ak, rime_ok]
+
+
+#覺B
+rime_iwk = "iꞣ.."
+#藥A
+rime_ewk = "eꞣ.."
+#藥B
+rime_awk = "aꞣ.."
+###*əwk, *uwk, *owk n/a
+#list of *-wk coda rimes
+rimes_wkcoda = [rime_iwk, rime_ewk, rime_awk]
+
+
+#脂
+rime_ij = "ij.."
+#微A
+rime_əj = "əj.."
+#微B
+rime_uj = "uj.."
+#歌A
+rime_ej = "ej.."
+#歌B
+rime_aj = "aj.."
+#歌C
+rime_oj = "oj.."
+#list of *-j coda rimes
+rimes_jcoda = [rime_ij, rime_əj, rime_uj, rime_ej, rime_aj, rime_oj]
+
+#質 ought to include both *-it AND *-ik
+rime_it = "it.."
+rhgroup_質 = is_rhgroup([rime_it, rime_ik])
+#物A
+rime_ət = "ət.."
+#物B
+rime_ut = "ut.."
+#月|祭A
+rime_et = "et.."
+#月|祭B
+rime_at = "at.."
+#月|祭C
+rime_ot = "ot.."
+#list of *-t coda rimes
+rimes_tcoda = [rhgroup_質, rime_ət, rime_ut, rime_et, rime_at, rime_ot]
+
+
+#真 includes *-iŋ
+rime_in = "in.."
+rime_iŋ = "iŋ.."
+rhgroup_真 = is_rhgroup([rime_in, rime_iŋ])
+#文A
+rime_ən = "ən.."
+#文B
+rime_un = "un.."
+#元A
+rime_en = "en.."
+#元B
+rime_an = "an.."
+#元C
+rime_on = "on.."
+#list of *-n coda rimes
+rimes_ncoda = [rhgroup_真, rime_ən, rime_un, rime_en, rime_an, rime_on]
+
+
+#文C
+rime_ər = "ər.."
+#文D
+rime_ur = "ur.."
+#元E
+rime_er = "er.."
+#元D
+rime_ar = "ar.."
+#元F
+rime_or = "or.."
+#list of *-r coda rimes
+rimes_rcoda = [rime_ər, rime_ur, rime_er, rime_ar, rime_or]
+
+
+#*-iŋ under 真
+#蒸
+rime_əŋ = "əŋ.."
+#冬
+rime_uŋ = "uŋ.."
+#耕
+rime_eŋ = "eŋ.."
+#陽
+rime_aŋ = "aŋ.."
+#東
+rime_oŋ = "oŋ.."
+#list of *-ŋ coda rimes
+rimes_ŋcoda = [rime_əŋ, rime_uŋ, rime_eŋ, rime_aŋ, rime_oŋ]
+
+#侵A
+rime_im = "im.."
+#侵B
+rime_əm = "əm.."
+#侵C
+rime_um = "um.."
+#談A
+rime_em = "em.."
+#談B
+rime_am = "am.."
+#談C
+rime_om = "om.."
+#list of *-m coda rimes
+rimes_mcoda = [rime_im, rime_əm, rime_um, rime_em, rime_am, rime_om]
+
+#緝A
+rime_ip = "ip.."
+#緝B
+rime_əp = "əp.."
+#緝C
+rime_up = "up.."
+#盍A
+rime_ep = "ep.."
+#盍B
+rime_ap = "ap.."
+#盍C
+rime_op = "op.."
+#list of *-p coda rimes
+rimes_pcoda = [rime_ip, rime_əp, rime_up, rime_ep, rime_ap, rime_op]
+
+
+#list of all rimes
+rimes = rimes_opencoda + rimes_wcoda + rimes_kcoda + rimes_wkcoda + rimes_jcoda + rimes_tcoda + rimes_ncoda + rimes_rcoda + rimes_ŋcoda + rimes_mcoda + rimes_pcoda
+
+
+#lists of rhyme groups (rgroup) by trad. assigned character
+rhgroup_幽 = is_rhgroup([rime_u, rime_iw])
+rhgroup_宵 = is_rhgroup([rime_ew, rime_aw])
+rhgroup_覺 = is_rhgroup([rime_uk, rime_iwk])
+rhgroup_藥 = is_rhgroup([rime_ewk, rime_awk])
+rhgroup_微 = is_rhgroup([rime_əj, rime_uj])
+rhgroup_歌 = is_rhgroup([rime_ej, rime_aj, rime_oj])
+rhgroup_物 = is_rhgroup([rime_ət, rime_ut])
+rhgroup_月 = is_rhgroup([rime_et, rime_at, rime_ot])
+rhgroup_文 = is_rhgroup([rime_ən, rime_un, rime_ur, rime_ər])
+rhgroup_元 = is_rhgroup([rime_en, rime_an, rime_on, rime_ar, rime_er, rime_or])
+rhgroup_侵 = is_rhgroup([rime_im, rime_əm, rime_um])
+rhgroup_談 = is_rhgroup([rime_em, rime_am, rime_om])
+rhgroup_緝 = is_rhgroup([rime_ip, rime_əp, rime_up])
+rhgroup_盍 = is_rhgroup([rime_ep, rime_ap, rime_op])
+rhgroups = [rhgroup_幽] + [rhgroup_宵] + [rhgroup_覺] + [rhgroup_藥] + [rhgroup_微] + [rhgroup_歌] + [rhgroup_物] + [rhgroup_月] + [rhgroup_文] + [rhgroup_元] + [rhgroup_侵] + [rhgroup_談] + [rhgroup_緝] + [rhgroup_盍] 
+
+
+#list of common cross-rhymes
+#之/幽
+crgroup_之幽 = is_rhgroup([rime_ə, rhgroup_幽])
+#魚/之
+crgroup_魚之 = is_rhgroup([rime_a, rime_ə])
+#魚/侯
+crgroup_魚侯 = is_rhgroup([rime_a, rime_o])
+#支/之
+crgroup_支之 = is_rhgroup([rime_e, rime_ə])
+
+
+#魚/歌
+crgroup_魚歌 = is_rhgroup([rime_a, rhgroup_歌])
+#歌/之
+crgroup_歌之 = is_rhgroup([rhgroup_歌, rime_ə])
+#歌/脂
+crgroup_歌脂 = is_rhgroup([rhgroup_歌, rime_ij])
+#歌/微
+crgroup_歌微 = is_rhgroup([rhgroup_歌, rhgroup_微])
+#微/脂
+crgroup_微脂 = is_rhgroup([rhgroup_微, rime_ij])
+
+
+#陽/東
+crgroup_陽東 = is_rhgroup([rime_aŋ, rime_oŋ])
+#陽/耕
+crgroup_陽耕 = is_rhgroup([rime_aŋ, rime_eŋ])
+#耕/真
+crgroup_耕真 = is_rhgroup([rime_eŋ, rhgroup_真])
+
+#真/文
+crgroup_真文 = is_rhgroup([rhgroup_真, rhgroup_文])
+#真/元
+crgroup_真元 = is_rhgroup([rhgroup_真, rhgroup_元])

--- a/src/dphon/fuzzyphon.py
+++ b/src/dphon/fuzzyphon.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Phonological equivalence classes for fuzzy *seeding* in dphon.
+
+Two orthogonal, opt-in relaxations of the exact-phoneme seed key. Neither
+touches the verbatim phonemes used for extension, alignment, display, or
+scoring -- they only change which n-grams seed together.
+
+1. INITIAL place classes (``build_initial_classes``).
+   * A "core" is a set of OBSTRUENTS at one place of articulation that differ
+     only in voicing/aspiration (e.g. *b- / *p- / *pʰ-). Cores are derived from
+     the ``oc-consonants.txt`` substitution matrix by connected components,
+     **restricted to obstruent nodes** so that sonorants can never act as
+     bridges. ``threshold`` is the single knob for core coarseness (>=7 keeps
+     clean place triples).
+   * Optionally (``fold_homorganic_nasals=True``) each NASAL is attached to the
+     single core it is most similar to (argmax over per-core max edge, gated by
+     ``nasal_threshold``). A nasal is a *leaf*: it joins a core but is never used
+     as a bridge, so liquids/glides/fricatives (l, r, j, s, ...) are never pulled
+     in. 
+
+2. RHYME classes (``load_rhyme_classes``).
+   * (nucleus, coda) pairs in the same traditional rhyme category (韻部) map to a
+     single label, so e.g. *-in / *-iŋ (真) seed together. Membership is read
+     from the curated Yunelizer-syntax file by PARSING it with ``ast`` -- never
+     by executing it. Only ``rhgroup_*`` (the 部 partition) is consumed; pairwise
+     ``crgroup_*`` cross-rhymes are intentionally ignored (a single-label
+     partition cannot represent cross-rhyme links without over-merging, 
+     so cross-rhymes are currently out of scope ).
+"""
+
+from __future__ import annotations
+
+import ast
+import csv
+import logging
+from importlib.resources.abc import Traversable
+from typing import Dict, List, Tuple
+
+# (nucleus, coda) -> rhyme-class label
+RhymeClasses_T = Dict[Tuple[str, str], str]
+# raw initial symbol -> place-class label
+InitialClasses_T = Dict[str, str]
+# raw nucleus -> normalized nucleus, applied to the seed key only
+NucleusNorm_T = Dict[str, str]
+
+# Symbols that may be *folded* into an obstruent core (only when requested).
+NASALS = frozenset({"m", "n", "ŋ", "ŋʷ"})
+# Sonorants that must never form, join, or bridge a core. They always remain
+# their own seed class. (Add to this set if the matrix grows new approximants.)
+NON_OBSTRUENT_APPROXIMANTS = frozenset({"l", "r", "j", "w"})
+
+
+# --------------------------------------------------------------------------- #
+# consonant matrix
+# --------------------------------------------------------------------------- #
+def load_consonant_matrix(path: Traversable) -> Dict[Tuple[str, str], int]:
+    """Load ``oc-consonants.txt`` as a {(row_symbol, col_symbol): score} map.
+
+    Fails fast on an empty file, a missing header, a blank row symbol, a short
+    row, or a non-integer cell -- silent mis-parses here corrupt every class.
+    """
+    with path.open(encoding="utf8") as file:
+        rows = list(csv.reader(file, delimiter="\t"))
+    if not rows:
+        raise ValueError(f"empty consonant matrix: {path}")
+
+    header = [cell.strip() for cell in rows[0][1:] if cell.strip()]
+    if not header:
+        raise ValueError(f"missing consonant-matrix header: {path}")
+
+    matrix: Dict[Tuple[str, str], int] = {}
+    for line_no, row in enumerate(rows[1:], start=2):
+        if not row or not any(cell.strip() for cell in row):
+            continue
+        sym = row[0].strip()
+        if not sym:
+            raise ValueError(f"blank row symbol at line {line_no}: {path}")
+        vals = [cell.strip() for cell in row[1:1 + len(header)]]
+        if len(vals) < len(header):
+            raise ValueError(f"short row for {sym!r} at line {line_no}: {path}")
+        for col, val in zip(header, vals):
+            try:
+                matrix[(sym, col)] = int(val)
+            except ValueError as exc:
+                raise ValueError(
+                    f"non-integer cell ({sym!r},{col!r})={val!r} at line {line_no}: {path}"
+                ) from exc
+    return matrix
+
+
+def _connected_components(
+    nodes: List[str], edges: Dict[str, set]
+) -> Dict[str, List[str]]:
+    """Deterministic connected components via iterative DFS.
+
+    Returns {component_label: sorted_members}, labelled by the
+    lexicographically smallest member.
+    """
+    seen: set = set()
+    comps: Dict[str, List[str]] = {}
+    for node in nodes:
+        if node in seen:
+            continue
+        stack, comp = [node], []
+        while stack:
+            cur = stack.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            comp.append(cur)
+            stack.extend(sorted(edges[cur] - seen))
+        comp.sort()
+        comps[comp[0]] = comp
+    return comps
+
+
+def build_initial_classes(
+    path: Traversable,
+    threshold: int = 7,
+    fold_homorganic_nasals: bool = False,
+    nasal_threshold: int = 5,
+) -> InitialClasses_T:
+    """Map each initial symbol to a place-class representative.
+
+    Args:
+        path: ``oc-consonants.txt``.
+        threshold: minimum pairwise score for two OBSTRUENTS to share a core.
+            >=7 yields clean voicing/aspiration triples per place.
+        fold_homorganic_nasals: if True, attach each nasal to the single core it
+            is most similar to. Off by default (nasals stay their own class).
+        nasal_threshold: minimum nasal-to-core score required to fold a nasal.
+
+    Only obstruents form cores, and only nasals may be folded in; liquids,
+    glides, and fricatives outside a core always map to themselves.
+    """
+    matrix = load_consonant_matrix(path)
+    symbols = sorted({a for a, _ in matrix} | {b for _, b in matrix})
+
+    # 1. obstruent cores -- restrict the graph to obstruents so no sonorant can
+    #    bridge two places or join a core.
+    obstruents = [
+        s for s in symbols
+        if s not in NASALS and s not in NON_OBSTRUENT_APPROXIMANTS
+    ]
+    obstruent_set = set(obstruents)
+    edges: Dict[str, set] = {s: set() for s in obstruents}
+    for (a, b), score in matrix.items():
+        if a != b and score >= threshold and a in obstruent_set and b in obstruent_set:
+            edges[a].add(b)
+            edges[b].add(a)
+
+    cores = _connected_components(obstruents, edges)  # label -> [members]
+    classes: InitialClasses_T = {}
+    for label, members in cores.items():
+        for member in members:
+            classes[member] = label
+
+    # 2. fold homorganic nasals as leaves (opt-in). Each nasal joins the core
+    #    with which it has its single highest edge; it never bridges.
+    if fold_homorganic_nasals:
+        for nasal in sorted(NASALS):
+            if nasal not in symbols:
+                continue
+            best_label, best_score = None, 0
+            for label in sorted(cores):
+                members = cores[label]
+                score = max((matrix.get((nasal, m), 0) for m in members), default=0)
+                if score > best_score:  # strict '>' => smallest label wins ties
+                    best_score, best_label = score, label
+            if best_label is not None and best_score >= nasal_threshold:
+                classes[nasal] = best_label
+            # else: no homorganic core -> nasal stays its own class
+
+    # 3. every remaining symbol (l, r, j, s, lone obstruents, unfolded nasals)
+    #    maps to itself: no relaxation.
+    for s in symbols:
+        classes.setdefault(s, s)
+
+    n_classes = len(set(classes.values()))
+    logging.info(
+        "built %d initial classes (threshold=%d, fold_nasals=%s) from %s",
+        n_classes, threshold, fold_homorganic_nasals,
+        getattr(path, "name", path),
+    )
+    if fold_homorganic_nasals:
+        folded = [n for n in sorted(NASALS) if n in classes and classes[n] != n]
+        logging.info("folded homorganic nasals: %s", folded or "none")
+    return classes
+
+
+# --------------------------------------------------------------------------- #
+# rhyme classes  (parse the Yunelizer file with ast; never exec it)
+# --------------------------------------------------------------------------- #
+# Yunelizer encodes a rime as "{nucleus}{coda}.." with these coda conventions;
+# translate to the (nucleus, coda) shape used by dphon's sound table.
+_YUNELIZER_CODA = {"0": "", "ꞣ": "wk"}
+
+
+def _decode_rime(rime: str) -> Tuple[str, str]:
+    """Decode a Yunelizer rime (e.g. 'iŋ..', 'ə0..') to (nucleus, coda).
+
+    Assumes a single-codepoint nucleus and a single-codepoint coda marker; this
+    holds for the entire current inventory. Multi-codepoint nuclei would need a
+    revised encoding here.
+    """
+    nucleus, coda = rime[0], rime[1]
+    return nucleus, _YUNELIZER_CODA.get(coda, coda)
+
+
+class _RhymeGroupReader(ast.NodeVisitor):
+    """Resolve a Yunelizer rhyme file into named groups WITHOUT executing it.
+
+    Supports exactly the grammar the file uses:
+        name = "literal"
+        name = [a, b, ...]                 # list of names/literals
+        name = a + b                       # list concatenation
+        name = is_rhgroup([a, b, ...])     # flattened group
+    Anything else raises, so a malformed/hostile file fails loudly instead of
+    running code.
+    """
+
+    def __init__(self) -> None:
+        self.env: Dict[str, Tuple[str, ...]] = {}
+        self.rhgroups: Dict[str, List[str]] = {}
+
+    def _resolve(self, node: ast.AST) -> Tuple[str, ...]:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return (node.value,)
+        if isinstance(node, ast.Name):
+            return self.env[node.id]
+        if isinstance(node, ast.List):
+            out: Tuple[str, ...] = ()
+            for elt in node.elts:
+                out += self._resolve(elt)
+            return out
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            return self._resolve(node.left) + self._resolve(node.right)
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == "is_rhgroup":
+            if len(node.args) != 1:
+                raise ValueError("is_rhgroup expects exactly one argument")
+            return self._resolve(node.args[0])
+        raise ValueError(f"unsupported expression in rhyme file: {ast.dump(node)}")
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            return
+        name = node.targets[0].id
+        value = self._resolve(node.value)
+        self.env[name] = value
+        # consume only the 部 partition; crgroup_* (cross-rhymes) are ignored.
+        if name.startswith("rhgroup_"):
+            self.rhgroups[name[len("rhgroup_"):]] = list(value)
+
+
+def load_rhyme_classes(path: Traversable) -> RhymeClasses_T:
+    """Build a (nucleus, coda) -> 部-label map from a Yunelizer-syntax file.
+
+    The file is parsed with ``ast`` (no execution). Each ``rhgroup_X`` becomes a
+    class labelled ``X`` whose members are its rimes decoded to (nucleus, coda).
+    Combos absent from any rhgroup get no entry and fall back to exact identity.
+    Pairwise ``crgroup_*`` cross-rhymes are deliberately not consumed.
+    """
+    reader = _RhymeGroupReader()
+    with path.open(encoding="utf8") as file:
+        tree = ast.parse(file.read())
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            reader.visit_Assign(stmt)
+
+    classes: RhymeClasses_T = {}
+    for label, rimes in reader.rhgroups.items():
+        for rime in rimes:
+            classes[_decode_rime(rime)] = label
+
+    logging.info(
+        "loaded %d rhyme-class assignments in %d classes from %s",
+        len(classes), len(reader.rhgroups), getattr(path, "name", path),
+    )
+    return classes
+
+
+# --------------------------------------------------------------------------- #
+# validation against the live sound table  (warn, never raise on a superset)
+# --------------------------------------------------------------------------- #
+def _attested(sound_table, idx: int) -> set:
+    return {r[idx] for r in sound_table.values() if len(r) > idx}
+
+
+def warn_unattested_initials(sound_table, initial_classes, initial_idx: int = 3) -> None:
+    """Log (do NOT raise) initials in the matrix that never occur as a token.
+
+    The consonant matrix is a superset of any one table's initial inventory
+     (e.g. 'j', 'wk'), so this is informational only.
+    """
+    unknown = sorted(set(initial_classes) - _attested(sound_table, initial_idx))
+    if unknown:
+        logging.warning("initial classes include unattested initials: %s", unknown[:20])
+
+
+def warn_unattested_rhymes(
+    sound_table,
+    rhyme_classes,
+    nucleus_idx: int = 6,
+    coda_idx: int = 7,
+    nucleus_norm: NucleusNorm_T | None = None,
+) -> None:
+    """Log (do NOT raise) rhyme keys that never occur in the table.
+
+    ``nucleus_norm`` must match the normalization applied when the seed key is
+    built (e.g. {'A': 'a'}); otherwise normalized keys spuriously look absent.
+    """
+    norm = nucleus_norm or {}
+    attested = {
+        (norm.get(r[nucleus_idx], r[nucleus_idx]), r[coda_idx])
+        for r in sound_table.values()
+        if len(r) > max(nucleus_idx, coda_idx)
+    }
+    unknown = sorted(set(rhyme_classes) - attested)
+    if unknown:
+        logging.warning("rhyme classes include unattested (nucleus,coda): %s", unknown[:20])

--- a/src/dphon/g2p.py
+++ b/src/dphon/g2p.py
@@ -178,6 +178,32 @@ class GraphemesToPhonemes:
     def _get_syllables(self, tokens: Iterable[Token]) -> List[str]:
         return [self._get_token_syllable(token) for token in tokens]
 
+    def get_token_seed_key(self, token: Token) -> str:
+        """Collision-safe fuzzy *seed* key for `token`, as a string.
+
+        Must be a string (not a tuple): the index stores keys in a spaCy
+        `Table`, whose bloom filter requires keys that hash to an int. \x1f /
+        \x1e are field/record separators that never occur in phonemes or class
+        labels. With empty fuzzy config this reduces to the exact
+        (initial, nucleus, coda), so seeding behavior is preserved.
+        """
+        phonemes = self.get_token_phonemes(token)
+        if phonemes == self.empty_phonemes:
+            return "\x00EMPTY"
+        if phonemes == (OOV_PHONEMES,):
+            return "\x00OOV"
+        initial, nucleus, coda = phonemes              # selected 3-tuple: 0,1,2
+        initial_key = self.initial_classes.get(initial, initial)
+        nucleus_key = self.nucleus_norm.get(nucleus, nucleus)
+        rhyme_key = self.rhyme_classes.get((nucleus_key, coda))
+        if rhyme_key is not None:
+            return f"I{initial_key}\x1fR{rhyme_key}"
+        return f"I{initial_key}\x1fN{nucleus_key}\x1fC{coda}"
+
+    def get_span_seed_key(self, tokens: Iterable[Token]) -> str:
+        """Collision-safe structured seed key for an n-gram span."""
+        return "\x1e".join(self.get_token_seed_key(t) for t in tokens)
+
     def _select(self, reading: Phonemes_T) -> Phonemes_T:
         """Filter the syllable to only the segments we're interested in."""
         # NOTE using only initial, nucleus, coda currently
@@ -185,7 +211,7 @@ class GraphemesToPhonemes:
         nucleus = reading[6]
         coda = reading[7]
         return (initial, nucleus, coda)
-
+    
     def get_token_seed_key(self, token: Token) -> Tuple[str, ...]:
         """Fuzzy *seed* key for `token`; exact phonemes are left untouched.
 

--- a/src/dphon/g2p.py
+++ b/src/dphon/g2p.py
@@ -12,6 +12,7 @@ from spacy.lookups import Table
 from spacy.tokens import Doc, Span, Token
 
 from dphon.match import Match
+from dphon.fuzzyphon import InitialClasses_T, NucleusNorm_T, RhymeClasses_T
 
 # private use unicode char that represents phonemes for OOV tokens
 OOV_PHONEMES = "\ue000"
@@ -40,10 +41,23 @@ class GraphemesToPhonemes:
 
     _table: Table  # uses spaCy's lookup tables (bloom filtered dict)
 
-    def __init__(self, nlp: Language, sound_table: SoundTable_T):
+    def __init__(
+        self,
+        nlp: Language,
+        sound_table: SoundTable_T,
+        initial_classes: Optional[InitialClasses_T] = None,
+        rhyme_classes: Optional[RhymeClasses_T] = None,
+        nucleus_norm: Optional[NucleusNorm_T] = None,
+    ):
         # infer the syllable segmentation and map it to an empty phoneme set
         syllable_parts = len(next(iter(sound_table.values())))
         self.empty_phonemes = tuple(None for _ in range(syllable_parts))
+
+        # fuzzy seed-classes; empty by default => exact seeding behavior.
+        # populated post-construction in cli.setup() (see Step 4c).
+        self.initial_classes: InitialClasses_T = initial_classes or {}
+        self.rhyme_classes: RhymeClasses_T = rhyme_classes or {}
+        self.nucleus_norm: NucleusNorm_T = nucleus_norm or {}
 
         # register extensions on spaCy primitives
         if not Doc.has_extension("phonemes"):
@@ -56,6 +70,10 @@ class GraphemesToPhonemes:
             Token.set_extension("phonemes", getter=self.get_token_phonemes)
         if not Token.has_extension("is_oov"):
             Token.set_extension("is_oov", getter=self.is_token_oov)
+        if not Token.has_extension("seed_key"):
+            Token.set_extension("seed_key", getter=self.get_token_seed_key)
+        if not Span.has_extension("seed_key"):
+            Span.set_extension("seed_key", getter=self.get_span_seed_key)
 
         # store the sound table in the vocab's Lookups
         self.table = nlp.vocab.lookups.add_table("phonemes", sound_table)
@@ -168,6 +186,29 @@ class GraphemesToPhonemes:
         coda = reading[7]
         return (initial, nucleus, coda)
 
+    def get_token_seed_key(self, token: Token) -> Tuple[str, ...]:
+        """Fuzzy *seed* key for `token`; exact phonemes are left untouched.
+
+        `get_token_phonemes` (used for extension/alignment/display) is unchanged.
+        With empty fuzzy config this key is equivalent to the exact phonemes, so
+        default seeding is preserved.
+        """
+        phonemes = self.get_token_phonemes(token)
+        if phonemes == self.empty_phonemes:
+            return ("EMPTY",)
+        if phonemes == (OOV_PHONEMES,):
+            return ("OOV",)
+        initial, nucleus, coda = phonemes              # selected 3-tuple: 0,1,2
+        initial_key = self.initial_classes.get(initial, initial)
+        nucleus_key = self.nucleus_norm.get(nucleus, nucleus)
+        rhyme_key = self.rhyme_classes.get((nucleus_key, coda))
+        if rhyme_key is not None:
+            return ("I", initial_key, "R", rhyme_key)
+        return ("I", initial_key, "N", nucleus_key, "C", coda)
+
+    def get_span_seed_key(self, tokens: Iterable[Token]) -> Tuple[Tuple[str, ...], ...]:
+        """Hashable structured seed key for an n-gram span."""
+        return tuple(self.get_token_seed_key(token) for token in tokens)
 
 def get_sound_table_json(path: Traversable) -> SoundTable_T:
     """Load a sound table as JSON."""

--- a/src/dphon/g2p.py
+++ b/src/dphon/g2p.py
@@ -211,30 +211,7 @@ class GraphemesToPhonemes:
         nucleus = reading[6]
         coda = reading[7]
         return (initial, nucleus, coda)
-    
-    def get_token_seed_key(self, token: Token) -> Tuple[str, ...]:
-        """Fuzzy *seed* key for `token`; exact phonemes are left untouched.
 
-        `get_token_phonemes` (used for extension/alignment/display) is unchanged.
-        With empty fuzzy config this key is equivalent to the exact phonemes, so
-        default seeding is preserved.
-        """
-        phonemes = self.get_token_phonemes(token)
-        if phonemes == self.empty_phonemes:
-            return ("EMPTY",)
-        if phonemes == (OOV_PHONEMES,):
-            return ("OOV",)
-        initial, nucleus, coda = phonemes              # selected 3-tuple: 0,1,2
-        initial_key = self.initial_classes.get(initial, initial)
-        nucleus_key = self.nucleus_norm.get(nucleus, nucleus)
-        rhyme_key = self.rhyme_classes.get((nucleus_key, coda))
-        if rhyme_key is not None:
-            return ("I", initial_key, "R", rhyme_key)
-        return ("I", initial_key, "N", nucleus_key, "C", coda)
-
-    def get_span_seed_key(self, tokens: Iterable[Token]) -> Tuple[Tuple[str, ...], ...]:
-        """Hashable structured seed key for an n-gram span."""
-        return tuple(self.get_token_seed_key(token) for token in tokens)
 
 def get_sound_table_json(path: Traversable) -> SoundTable_T:
     """Load a sound table as JSON."""

--- a/src/dphon/index.py
+++ b/src/dphon/index.py
@@ -165,13 +165,14 @@ class NgramPhonemesLookupsIndex(LookupsIndex[Span]):
             if ngram.text.isalpha() and OOV_PHONEMES not in ngram._.phonemes:
                 yield ngram
 
-    def _get_key(self, val: Span) -> Hashable:
-        """Structured seed key for an ngram.
+    def _get_key(self, val: Span) -> str:
+        """String seed key for an ngram.
 
-        Uses fuzzy seed equivalence when configured; exact phonemes are
-        unchanged everywhere else in the pipeline.
+        The spaCy `Table` hashes keys to ints via a bloom filter and rejects
+        tuples, so coerce to a string here regardless of seed_key's form.
         """
-        return val._.seed_key
+        key = val._.seed_key
+        return key if isinstance(key, str) else str(key)
 
 @Language.factory("ngram_phonemes_index")
 def create_ngram_phonemes_lookup_index(

--- a/src/dphon/index.py
+++ b/src/dphon/index.py
@@ -165,10 +165,13 @@ class NgramPhonemesLookupsIndex(LookupsIndex[Span]):
             if ngram.text.isalpha() and OOV_PHONEMES not in ngram._.phonemes:
                 yield ngram
 
-    def _get_key(self, val: Span) -> str:
-        """All phonetic content of an ngram as a string."""
-        return "".join(val._.phonemes)
+    def _get_key(self, val: Span) -> Hashable:
+        """Structured seed key for an ngram.
 
+        Uses fuzzy seed equivalence when configured; exact phonemes are
+        unchanged everywhere else in the pipeline.
+        """
+        return val._.seed_key
 
 @Language.factory("ngram_phonemes_index")
 def create_ngram_phonemes_lookup_index(

--- a/src/dphon/match.py
+++ b/src/dphon/match.py
@@ -10,6 +10,10 @@ from rich.console import Console, ConsoleOptions, RenderResult
 from rich.table import Table
 from spacy.tokens import Span
 
+# Internal sentinel marking an alignment gap in au/av. Must be a character that
+# cannot occur in corpus text, so a literal gap-like character (e.g. U+3000) is
+# never mistaken for a gap during scoring or colorization. Rendered as 　 in output.
+GAP = "\x00"
 
 class Match(NamedTuple):
     """A match is a pair of similar textual sequences in two documents."""
@@ -94,8 +98,8 @@ class Match(NamedTuple):
             "v_id": self.v,
             "u_text": self.utxt.text,
             "v_text": self.vtxt.text,
-            "u_text_aligned": "".join(self.au),
-            "v_text_aligned": "".join(self.av),
+            "u_text_aligned": "".join(self.au).replace(GAP, "　"),
+            "v_text_aligned": "".join(self.av).replace(GAP, "　"),
             "u_transcription": self.u_transcription,
             "v_transcription": self.v_transcription,
             "u_start": self.utxt.start,

--- a/src/dphon/reuse.py
+++ b/src/dphon/reuse.py
@@ -184,6 +184,15 @@ class MatchGraph:
                     extended = extend_matches(matches, extender)
                     G.add_edges_from([(m.u, m.v, m._asdict()) for m in extended])
                     self.progress.update(task, advance=len(edges))
+            # process self-loops (same-doc matches)
+            for node in self._G.nodes:
+                edges = self._G.get_edge_data(node, node)
+                if edges:
+                    self.progress.update(task, u=node, v=node)
+                    matches = [Match(**data) for data in edges.values()]
+                    extended = extend_matches(matches, extender)
+                    G.add_edges_from([(m.u, m.v, m._asdict()) for m in extended])
+                    self.progress.update(task, advance=len(edges))
         self._G = G
         self.progress.remove_task(task)
 
@@ -201,6 +210,15 @@ class MatchGraph:
                 edges = self._G.get_edge_data(u, v)
                 if edges:
                     self.progress.update(task, u=u, v=v)
+                    matches = [Match(**data) for data in edges.values()]
+                    aligned = [align(match) for match in matches]
+                    G.add_edges_from([(m.u, m.v, m._asdict()) for m in aligned])
+                    self.progress.update(task, advance=len(edges))
+            # process self-loops (same-doc matches)
+            for node in self._G.nodes:
+                edges = self._G.get_edge_data(node, node)
+                if edges:
+                    self.progress.update(task, u=node, v=node)
                     matches = [Match(**data) for data in edges.values()]
                     aligned = [align(match) for match in matches]
                     G.add_edges_from([(m.u, m.v, m._asdict()) for m in aligned])


### PR DESCRIPTION
5 commits: one bug fix and 4 that add new features:
- fix: alignment issue in producing OC transcription. 
- feature 1: added a --transcribe-context flag to also render OC transcription of context characters
- feature 2: added color-coding of OC transcription mimicking base text, to allow for easier manual review
- feature 3: added --within-doc flag to allow within-document matching (e.g., to detect parallels within same chapters of text A). This was previously skipped. I decided to make this an option, rather than a bug fix, to allow for more customization.
- feature 4: added --focus <ID> flag to allow for one-to-many matching (e.g., from text A to text B, C, D, etc., without including matches between B <--> C, B <--> D, C <--> D, etc.)