### PR TITLE
new feature: add --within-doc flag for intra-document matching

### DIFF
--- a/src/dphon/cli.py
+++ b/src/dphon/cli.py
@@ -45,6 +45,9 @@ Matching Options:
         a dimmed appearance if color is supported in the terminal.
 
 Filtering Options:
+    --within-doc               [default: False]
+        Allow matches within the same document. Overlapping spans are
+        automatically excluded.
     -a, --all
         Allow matches without graphic variation. By default, only matches
         containing at least one token with shared phonemes but differing
@@ -75,6 +78,9 @@ Filtering Options:
         to allow matches that are phonetically identical (1).
 
 Display options:
+    --transcribe-context        [default: False]
+        Include phonemic transcription for context tokens as well as matched
+        tokens.
     -g, --group                [default: False]
         Group matches by shared text. By default, matches are displayed as
         individual pairs of similar sequences.
@@ -144,7 +150,7 @@ def run() -> None:
 
     # setup match highlighting
     console.highlighter = MatchHighlighter(
-        g2p=nlp.get_pipe("g2p"), context=int(args["--context"]), gap_char="　"
+        g2p=nlp.get_pipe("g2p"), context=int(args["--context"]), gap_char="　", transcribe_context=args["--transcribe-context"]
     )
 
     # process all texts
@@ -253,7 +259,7 @@ def process(nlp: Language, args: Dict) -> MatchGraph:
             )
             progress.update(task, seed=locations[0].text)
             for utxt, vtxt in combinations(locations, 2):
-                if utxt.doc._.id != vtxt.doc._.id:  # skip same-doc matches
+                if utxt.doc._.id != vtxt.doc._.id or (args["--within-doc"] and (utxt.end <= vtxt.start or vtxt.end <= utxt.start)):
                     graph.add_match(
                         Match(utxt.doc._.id, vtxt.doc._.id, utxt, vtxt, 1.0)
                     )
@@ -272,6 +278,14 @@ def process(nlp: Language, args: Dict) -> MatchGraph:
             threshold=float(args["--threshold"]), len_limit=int(args["--len-limit"])
         )
     )
+    
+    # remove same-doc matches that overlap after extension
+    if args["--within-doc"]:
+        def no_overlap(match: Match) -> bool:
+            if match.u != match.v:
+                return True
+            return match.utxt.end <= match.vtxt.start or match.vtxt.end <= match.utxt.start
+        graph.filter(no_overlap)
 
     # align all matches
     graph.align(SmithWatermanPhoneticAligner(gap_char="　"))

--- a/src/dphon/reuse.py
+++ b/src/dphon/reuse.py
@@ -184,6 +184,15 @@ class MatchGraph:
                     extended = extend_matches(matches, extender)
                     G.add_edges_from([(m.u, m.v, m._asdict()) for m in extended])
                     self.progress.update(task, advance=len(edges))
+            # process self-loops (same-doc matches)
+            for node in self._G.nodes:
+                edges = self._G.get_edge_data(node, node)
+                if edges:
+                    self.progress.update(task, u=node, v=node)
+                    matches = [Match(**data) for data in edges.values()]
+                    extended = extend_matches(matches, extender)
+                    G.add_edges_from([(m.u, m.v, m._asdict()) for m in extended])
+                    self.progress.update(task, advance=len(edges))
         self._G = G
         self.progress.remove_task(task)
 
@@ -201,6 +210,15 @@ class MatchGraph:
                 edges = self._G.get_edge_data(u, v)
                 if edges:
                     self.progress.update(task, u=u, v=v)
+                    matches = [Match(**data) for data in edges.values()]
+                    aligned = [align(match) for match in matches]
+                    G.add_edges_from([(m.u, m.v, m._asdict()) for m in aligned])
+                    self.progress.update(task, advance=len(edges))
+            # process self-loops (same-doc matches)
+            for node in self._G.nodes:
+                edges = self._G.get_edge_data(node, node)
+                if edges:
+                    self.progress.update(task, u=node, v=node)
                     matches = [Match(**data) for data in edges.values()]
                     aligned = [align(match) for match in matches]
                     G.add_edges_from([(m.u, m.v, m._asdict()) for m in aligned])


### PR DESCRIPTION
Allow finding parallel passages within the same document by:
- Adding --within-doc CLI flag to enable same-doc seed generation
- Adding post-extension overlap filter to exclude self-overlapping spans
- Processing self-loops in MatchGraph.extend() and MatchGraph.align()
  (combinations(nodes, 2) skips u==v pairs, so self-loops need a
  separate iteration)
